### PR TITLE
Fixed adding layer using ->contents()

### DIFF
--- a/src/Engine/PhpGd/Extension/Core/EventListener/ImageAwareLayerListener.php
+++ b/src/Engine/PhpGd/Extension/Core/EventListener/ImageAwareLayerListener.php
@@ -66,6 +66,7 @@ class ImageAwareLayerListener implements EventSubscriberInterface
             if (!($layer instanceof ImageAwareLayerInterface)) {
                 continue;
             }
+            $arr = false;
             if ($layer->has('image.http.url')) {
                 $arr = [
                     'uri'        => $layer->get('image.http.url'),
@@ -80,8 +81,10 @@ class ImageAwareLayerListener implements EventSubscriberInterface
                     'seek' => true
                 ];
             }
-            $uri = 'imc://'.serialize($arr);
-            $layer->set('image.imc_uri', $uri);
+            if ($arr) {
+                $uri = 'imc://'.serialize($arr);
+                $layer->set('image.imc_uri', $uri);
+            }
         }
     }
 


### PR DESCRIPTION
Hello,

I could not create layers with the $layer->contents() method, because on save() the following error was issued:
The file "" was not found or could not be accessed.

The root cause for this was that imc:// uri was set regardless of the origin of the content.

Please review my fix, and apply it to the mainline if you find it appropriate
