### PR TITLE
Fixed issue with resizing animated GIFs

### DIFF
--- a/src/Engine/PhpGd/Helper/ResourceHelper.php
+++ b/src/Engine/PhpGd/Helper/ResourceHelper.php
@@ -21,7 +21,7 @@ class ResourceHelper
      */
     public function getEmptyGdResource($width, $height)
     {
-        $resource = imagecreatetruecolor($width, $height);
+        $resource = imagecreate($width, $height);
         imagesavealpha($resource, true);
         imagealphablending($resource, true);
         $trans = imagecolorallocatealpha($resource, 255, 255, 255, 127);


### PR DESCRIPTION
When I would resize an animated GIF, there would be certain resized versions that had a larger file size than the original GIF. For example when resizing a  400x227 980KB animated GIF to the dimensions 300x170, would result in a file size of 1.52MB (for the 300x170 GIF). Changing imagecreatetruecolor to imagecreate in getEmptyGdResource seems to fix this issue.